### PR TITLE
Use generateName in Devfiles

### DIFF
--- a/scaffolder-templates/quarkus-template/skeleton/.devfilev2-intellij.yaml
+++ b/scaffolder-templates/quarkus-template/skeleton/.devfilev2-intellij.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 2.1.0
 metadata:
-  name: ${{values.artifact_id}}
+  generateName: ${{values.artifact_id}}
 components:
   - name: development-tooling
     container:

--- a/scaffolder-templates/quarkus-template/skeleton/.devfilev2-theia.yaml
+++ b/scaffolder-templates/quarkus-template/skeleton/.devfilev2-theia.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 2.1.0
 metadata:
-  name: ${{values.artifact_id}}
+  generateName: ${{values.artifact_id}}
 components:
   - name: development-tooling
     container:

--- a/scaffolder-templates/quarkus-template/skeleton/.devfilev2-vscode.yaml
+++ b/scaffolder-templates/quarkus-template/skeleton/.devfilev2-vscode.yaml
@@ -1,6 +1,6 @@
 schemaVersion: 2.1.0
 metadata:
-  name: ${{values.artifact_id}}
+  generateName: ${{values.artifact_id}}
 components:
   - name: development-tooling
     container:


### PR DESCRIPTION
When using `metadata.generateName` rather than `metadata.name` a random suffix is added to the workspaces name. That avoid collisions when creating multiple workspaces using the same devfile.